### PR TITLE
feat: add pipecat optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Repository = "https://github.com/roarkhq/sdk-roark-analytics-python"
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
-pipecat = ["pipecat-roark>=0.1.1,<1"]
+pipecat = ["pipecat-roark==0.1.2"]
 
 [tool.rye]
 managed = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Repository = "https://github.com/roarkhq/sdk-roark-analytics-python"
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
-pipecat = ["pipecat-roark>=0.1.0,<1"]
+pipecat = ["pipecat-roark>=0.1.1,<1"]
 
 [tool.rye]
 managed = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Repository = "https://github.com/roarkhq/sdk-roark-analytics-python"
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
-pipecat = ["pipecat-roark==0.1.2"]
+pipecat = ["pipecat-roark==0.1.2; python_version >= '3.10'"]
 
 [tool.rye]
 managed = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ Repository = "https://github.com/roarkhq/sdk-roark-analytics-python"
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
+pipecat = ["pipecat-roark>=0.1.0,<1"]
 
 [tool.rye]
 managed = true


### PR DESCRIPTION
## Summary

Adds a `pipecat` provider-extra to `roark-analytics` so that:

- `pip install roark-analytics[pipecat]` transparently installs [`pipecat-roark`](https://pypi.org/project/pipecat-roark/) (the Roark analytics observer for [Pipecat](https://github.com/pipecat-ai/pipecat)).
- The PyPI page for `roark-analytics` advertises `Provides-Extra: pipecat` in the sidebar — same mechanism as the existing `aiohttp` extra — so users discovering the SDK can find the integration without a separate search.

## Change

```diff
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
+pipecat = ["pipecat-roark>=0.1.0,<1"]
```

Pin matches the project's `httpx<1,>=0.23.0` style — opts into pre-1.0 caution.

## Notes

- `pyproject.toml` is hand-edited and persisted across Stainless regenerations (per `CONTRIBUTING.md`), so no generator-side change is required.
- Pure packaging metadata change — no source code or codegen impact.
- Verified locally: `ruff check .` passes, `python -m build` succeeds, built wheel METADATA contains `Provides-Extra: pipecat` and `Requires-Dist: pipecat-roark<1,>=0.1.0; extra == 'pipecat'`.

## Test plan

- [ ] CI lint/build/test passes on this PR
- [ ] After merge + release, confirm `pipecat` shows under "Provides-Extra" on https://pypi.org/project/roark-analytics/
- [ ] `pip install roark-analytics[pipecat]` in a fresh venv installs both packages