### PR TITLE
fix: update pipecat extra to 0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Repository = "https://github.com/roarkhq/sdk-roark-analytics-python"
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
-pipecat = ["pipecat-roark==0.1.2; python_version >= '3.10'"]
+pipecat = ["pipecat-roark>=0.2,<0.3; python_version >= '3.10'"]
 
 [tool.rye]
 managed = true


### PR DESCRIPTION
## Summary

- update the unreleased `pipecat` extra from `pipecat-roark==0.1.2` to the supported `pipecat-roark>=0.2,<0.3` release line
- retain the Python 3.10 marker because `pipecat-roark` requires Python 3.10 or newer

## Why

The pending `roark-analytics` 2.24.0 release introduces `pip install "roark_analytics[pipecat]"`, but its generated metadata still selects the old 0.1.2 observer. Pipecat observer 0.2.0 contains the current runner-argument correlation contract. The bounded range accepts compatible 0.2 patch releases without silently adopting a potentially breaking 0.3 release.

Merging this change into `main` will also let Stainless refresh the existing 2.24.0 release PR, whose original GitHub Actions run is too old for GitHub to rerun.

## Validation

- `rye sync --all-features`
- `rye build`
- built wheel METADATA contains `Provides-Extra: pipecat`
- built wheel METADATA contains `Requires-Dist: pipecat-roark<0.3,>=0.2; (python_version >= '3.10') and extra == 'pipecat'`
- `./scripts/lint`
- `./scripts/test` (1,473 default-environment tests passed; 1,470 Pydantic v1 tests passed and 3 skipped)
- `git diff --check`
