### PR TITLE
fix(ci): allow stainless-app bot to trigger Claude PR review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Release and regeneration PRs are opened by the Stainless app, so the
+          # review job must accept that bot actor while still rejecting others.
+          allowed_bots: "stainless-app"
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Release and regeneration PRs in this repo are authored by the `stainless-app` GitHub App. `anthropics/claude-code-action` rejects non-`User` actors unless they are listed in `allowed_bots`, so the review job failed with:

> Workflow initiated by non-human actor: stainless-app (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

This adds `allowed_bots: "stainless-app"` to the PR Review step only. The `[bot]` suffix is normalized away on both sides by the action, so the bare name matches `stainless-app[bot]` too. `*` was deliberately not used — only the one bot that actually opens PRs here is allowed.

The `claude` job (`@claude` mentions) is left unchanged; it should stay human-triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)