### PR TITLE
ci: author the release PR here once the vendor stops

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,48 @@
+# Who authors the release PR once the vendor stops.
+#
+# Today `app/stainless-app` opens `release: <version>` against `main`, and
+# merging it tags, creates the GitHub release, and fires `publish-pypi.yml`. That
+# app is driven by the vendor's project config, so removing `targets.python` from
+# `stainless.yml` (app-roark-analytics#2905) stops it. Publishing itself is safe -
+# `publish-pypi.yml` lives here and listens for `release: published` - but with
+# nothing authoring the version bump, changelog and tag, generated code would
+# land on `main` and never ship.
+#
+# `release-please-config.json` and `.release-please-manifest.json` already exist
+# and are unchanged: this only supplies the runner they were always missing.
+name: release-please
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  # A second run while the first is opening or updating the release PR would race
+  # the same branch. Queue rather than cancel: a cancelled run can leave a pushed
+  # branch with no PR opened for it.
+  group: release-please
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    # Off until the vendor has actually let go. While `stainless.yml` still
+    # declares `targets.python`, both this and `app/stainless-app` would open a
+    # release PR into this repository. Set the RELEASE_PLEASE_ENABLED variable to
+    # 'true' in the same change that lands #2905, not before.
+    if: vars.RELEASE_PLEASE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          target-branch: main
+          # NOT GITHUB_TOKEN. A release created with it does not raise
+          # `release: published` for other workflows, so `publish-pypi.yml` would
+          # never run and this would reproduce the outage it exists to prevent -
+          # silently, since nothing fails when a publish simply never starts.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## ⚠️ Inert until a variable is set, and must not be enabled before app-roark-analytics#2905

`release-please-config.json` and `.release-please-manifest.json` have always been in this repository. Nothing ever ran them: `app/stainless-app` opens the `release: <version>` PR against `main`, and merging it tags, creates the GitHub release, and fires `publish-pypi.yml`.

That app is driven by the vendor's project config. Removing `targets.python` from `stainless.yml` (#2905) stops it.

Publishing itself survives, because `publish-pypi.yml` lives here and listens for `release: published`. What disappears is the thing that authors the version bump, changelog and tag. Without it, generated code lands on `main` and never ships, and nothing reports an error, because a publish that never starts doesn't fail.

This supplies the runner the config was always missing. It changes neither the config nor the manifest.

## Two things it deliberately gets right

**Gated on `RELEASE_PLEASE_ENABLED`.** While the vendor still declares `targets.python`, this and `app/stainless-app` would both open a release PR into this repository. Exactly one producer. Set the variable in the same change that lands #2905:

```bash
gh variable set RELEASE_PLEASE_ENABLED -R roarkhq/sdk-roark-analytics-python -b true
```

**Authenticates with `RELEASE_PLEASE_TOKEN`, not `GITHUB_TOKEN`.** A release created with `GITHUB_TOKEN` does not raise `release: published` for other workflows, so `publish-pypi.yml` would never start. That failure is silent, and it is exactly how the npm side went four months and two releases without publishing before anyone noticed. The token needs `contents: write` and `pull-requests: write` on this repo.

## One simplification worth flagging

The vendor's release branch is `release-please--branches--main--changes--next`, a fork-specific "changes branch" feature. This uses plain `target-branch: main`. `main` and `next` are currently identical (0 ahead, 0 behind), so the same commits are collected either way. If they are ever allowed to diverge, this is the line to revisit.

## Order

1. Merge this (inert)
2. Add `RELEASE_PLEASE_TOKEN`
3. Merge #2905, set `RELEASE_PLEASE_ENABLED=true`, merge app-agent-codegen#17 — one move
4. First generated PR: +7 resources, −3, merged with `feat!:` for the 3.0.0 major

🤖 Generated with [Claude Code](https://claude.com/claude-code)