### PR TITLE
fix(tests): point the client tests at an endpoint that still exists

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -879,20 +879,24 @@ class TestRoark:
     @mock.patch("roark_analytics._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
     def test_retrying_timeout_errors_doesnt_leak(self, respx_mock: MockRouter, client: Roark) -> None:
-        respx_mock.post("/v1/evaluation/job").mock(side_effect=httpx.TimeoutException("Test timeout error"))
+        respx_mock.post("/v1/webhook").mock(side_effect=httpx.TimeoutException("Test timeout error"))
 
         with pytest.raises(APITimeoutError):
-            client.evaluation.with_streaming_response.create_job(evaluators=["string"]).__enter__()
+            client.webhook.with_streaming_response.create(
+                events=["CALL_ANALYSIS_COMPLETED"], url="https://example.com"
+            ).__enter__()
 
         assert _get_open_connections(client) == 0
 
     @mock.patch("roark_analytics._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
     def test_retrying_status_errors_doesnt_leak(self, respx_mock: MockRouter, client: Roark) -> None:
-        respx_mock.post("/v1/evaluation/job").mock(return_value=httpx.Response(500))
+        respx_mock.post("/v1/webhook").mock(return_value=httpx.Response(500))
 
         with pytest.raises(APIStatusError):
-            client.evaluation.with_streaming_response.create_job(evaluators=["string"]).__enter__()
+            client.webhook.with_streaming_response.create(
+                events=["CALL_ANALYSIS_COMPLETED"], url="https://example.com"
+            ).__enter__()
         assert _get_open_connections(client) == 0
 
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
@@ -919,9 +923,11 @@ class TestRoark:
                 return httpx.Response(500)
             return httpx.Response(200)
 
-        respx_mock.post("/v1/evaluation/job").mock(side_effect=retry_handler)
+        respx_mock.post("/v1/webhook").mock(side_effect=retry_handler)
 
-        response = client.evaluation.with_raw_response.create_job(evaluators=["string"])
+        response = client.webhook.with_raw_response.create(
+            events=["CALL_ANALYSIS_COMPLETED"], url="https://example.com"
+        )
 
         assert response.retries_taken == failures_before_success
         assert int(response.http_request.headers.get("x-stainless-retry-count")) == failures_before_success
@@ -941,10 +947,12 @@ class TestRoark:
                 return httpx.Response(500)
             return httpx.Response(200)
 
-        respx_mock.post("/v1/evaluation/job").mock(side_effect=retry_handler)
+        respx_mock.post("/v1/webhook").mock(side_effect=retry_handler)
 
-        response = client.evaluation.with_raw_response.create_job(
-            evaluators=["string"], extra_headers={"x-stainless-retry-count": Omit()}
+        response = client.webhook.with_raw_response.create(
+            events=["CALL_ANALYSIS_COMPLETED"],
+            url="https://example.com",
+            extra_headers={"x-stainless-retry-count": Omit()},
         )
 
         assert len(response.http_request.headers.get_list("x-stainless-retry-count")) == 0
@@ -966,10 +974,12 @@ class TestRoark:
                 return httpx.Response(500)
             return httpx.Response(200)
 
-        respx_mock.post("/v1/evaluation/job").mock(side_effect=retry_handler)
+        respx_mock.post("/v1/webhook").mock(side_effect=retry_handler)
 
-        response = client.evaluation.with_raw_response.create_job(
-            evaluators=["string"], extra_headers={"x-stainless-retry-count": "42"}
+        response = client.webhook.with_raw_response.create(
+            events=["CALL_ANALYSIS_COMPLETED"],
+            url="https://example.com",
+            extra_headers={"x-stainless-retry-count": "42"},
         )
 
         assert response.http_request.headers.get("x-stainless-retry-count") == "42"
@@ -1797,20 +1807,24 @@ class TestAsyncRoark:
     @mock.patch("roark_analytics._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
     async def test_retrying_timeout_errors_doesnt_leak(self, respx_mock: MockRouter, async_client: AsyncRoark) -> None:
-        respx_mock.post("/v1/evaluation/job").mock(side_effect=httpx.TimeoutException("Test timeout error"))
+        respx_mock.post("/v1/webhook").mock(side_effect=httpx.TimeoutException("Test timeout error"))
 
         with pytest.raises(APITimeoutError):
-            await async_client.evaluation.with_streaming_response.create_job(evaluators=["string"]).__aenter__()
+            await async_client.webhook.with_streaming_response.create(
+                events=["CALL_ANALYSIS_COMPLETED"], url="https://example.com"
+            ).__aenter__()
 
         assert _get_open_connections(async_client) == 0
 
     @mock.patch("roark_analytics._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
     async def test_retrying_status_errors_doesnt_leak(self, respx_mock: MockRouter, async_client: AsyncRoark) -> None:
-        respx_mock.post("/v1/evaluation/job").mock(return_value=httpx.Response(500))
+        respx_mock.post("/v1/webhook").mock(return_value=httpx.Response(500))
 
         with pytest.raises(APIStatusError):
-            await async_client.evaluation.with_streaming_response.create_job(evaluators=["string"]).__aenter__()
+            await async_client.webhook.with_streaming_response.create(
+                events=["CALL_ANALYSIS_COMPLETED"], url="https://example.com"
+            ).__aenter__()
         assert _get_open_connections(async_client) == 0
 
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
@@ -1837,9 +1851,11 @@ class TestAsyncRoark:
                 return httpx.Response(500)
             return httpx.Response(200)
 
-        respx_mock.post("/v1/evaluation/job").mock(side_effect=retry_handler)
+        respx_mock.post("/v1/webhook").mock(side_effect=retry_handler)
 
-        response = await client.evaluation.with_raw_response.create_job(evaluators=["string"])
+        response = await client.webhook.with_raw_response.create(
+            events=["CALL_ANALYSIS_COMPLETED"], url="https://example.com"
+        )
 
         assert response.retries_taken == failures_before_success
         assert int(response.http_request.headers.get("x-stainless-retry-count")) == failures_before_success
@@ -1861,10 +1877,12 @@ class TestAsyncRoark:
                 return httpx.Response(500)
             return httpx.Response(200)
 
-        respx_mock.post("/v1/evaluation/job").mock(side_effect=retry_handler)
+        respx_mock.post("/v1/webhook").mock(side_effect=retry_handler)
 
-        response = await client.evaluation.with_raw_response.create_job(
-            evaluators=["string"], extra_headers={"x-stainless-retry-count": Omit()}
+        response = await client.webhook.with_raw_response.create(
+            events=["CALL_ANALYSIS_COMPLETED"],
+            url="https://example.com",
+            extra_headers={"x-stainless-retry-count": Omit()},
         )
 
         assert len(response.http_request.headers.get_list("x-stainless-retry-count")) == 0
@@ -1886,10 +1904,12 @@ class TestAsyncRoark:
                 return httpx.Response(500)
             return httpx.Response(200)
 
-        respx_mock.post("/v1/evaluation/job").mock(side_effect=retry_handler)
+        respx_mock.post("/v1/webhook").mock(side_effect=retry_handler)
 
-        response = await client.evaluation.with_raw_response.create_job(
-            evaluators=["string"], extra_headers={"x-stainless-retry-count": "42"}
+        response = await client.webhook.with_raw_response.create(
+            events=["CALL_ANALYSIS_COMPLETED"],
+            url="https://example.com",
+            extra_headers={"x-stainless-retry-count": "42"},
         )
 
         assert response.http_request.headers.get("x-stainless-retry-count") == "42"


### PR DESCRIPTION
Unblocks the `release: 3.0.0` PR (#472), which is red on `lint` and `test`.

## What broke

3.0.0 removes the `evaluation` resource. `tests/test_client.py` still called `client.evaluation.create_job`, so pyright reported **184 errors**, all descending from ten of these:

```
tests/test_client.py:1866:33 - error: Cannot access attribute "evaluation" for class "AsyncRoark"
    Attribute "evaluation" is unknown (reportAttributeAccessIssue)
```

## Why the generator didn't catch it

`tests/test_client.py` is **not generated**. The per-resource tests under `tests/api_resources/` are, and #469 rewrote all 16 of them. This one is the client-level suite: retries, timeouts, and the `x-stainless-retry-count` header. It exercises those behaviours through one arbitrarily chosen endpoint, and that endpoint happened to be `evaluation.create_job`.

It wasn't in #469's diff at all, which is why every gate passed and this still broke.

## Fix

Repointed at `webhook.create` — a POST with two simple required arguments. The retry and header assertions are unchanged in substance, because what these tests check is the client, not the endpoint. The endpoint is a fixture.

20 references replaced, across both the sync and async suites.

## Verification

pyright 1.1.399, the version CI pins:

| | Before | After |
|---|---|---|
| `Cannot access attribute` | 10 | **0** |
| `evaluation` references | 20 | **0** |

`ruff check` and `ruff format` clean. (A local pyright run also reports unrelated errors from dev stubs my environment lacks and CI installs via rye; those are identical before and after the patch.)

## Follow-up, not in this PR

The python generator in app-agent-codegen emits `tests/api_resources/` but leaves `tests/test_client.py` alone. Any future resource removal breaks it the same way, and does so *after* every gate has gone green. Either the generator should splice it, or a gate should fail when a generated removal orphans a reference outside the generated set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)